### PR TITLE
PSR exception 제거

### DIFF
--- a/PHP/README.md
+++ b/PHP/README.md
@@ -8,8 +8,6 @@
 - [2.4 Indenting](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md#24-indenting)
   - GitHub에서 신규로 관리되는 프로젝트는 space(4)를 사용 
   - 비공개로 유지되는 레거시 코드는 tab(4) 문자를 사용
-- [3. Declare Statements, Namespace, and Use Declarations](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md#3-declare-statements-namespace-and-use-declarations)
-    - declare 구분의 '=' 좌우에 공백을 삽입
 
 
 ## 버전


### PR DESCRIPTION
과거에는 IDE 에서 PSR 에 해당하는 코드 포메팅 기능을 지원하지 않아서 추가한 예외였으나, 최근에 해결되어 예외 규칙이 불필요해짐.