### PR TITLE
Update .swiftlint.yml

### DIFF
--- a/Swift/.swiftlint.yml
+++ b/Swift/.swiftlint.yml
@@ -2,10 +2,11 @@
 # Note 2: Xcode 에디터 특성상 의미 없음
 # Note 3: VC 구조상 지킬 수 없음
 # Note 4: API 관련 Data class와 JSI 설계를 위함
+# Note 5: 속도 향상을 위함
 
 disabled_rules:
-  - conditional_binding_cascade # 조건절 줄 바꿈 허용 (Note 1)
   - file_length # 파일 길이 제한 없음 (Note 3)
+  - for_where # for-in-where 강제 안함 (Note 1)
   - force_cast # 강제 cast 허용 (Note 1)
   - force_try # 강제 try 허용 (Note 1)
   - function_body_length # 함수 구현부 길이 제한 없음 (Note 1)
@@ -16,6 +17,13 @@ disabled_rules:
   - type_body_length # 타입 선언부 길이 제한 없음 (Note 3)
   - variable_name # 변수명 길이 제한 없음 (Note 4)
   - vertical_whitespace # 수직 여백 허용 (Note 1)
+
+opt_in_rules:
+  - empty_count # isEmpty 사용 강제 (Note 1, 5)
+  - closure_end_indentation # 클로저의 시작과 끝의 들여쓰기를 동일하게 맞추도록 (Note 1)
+  - closure_spacing # 클로저 표현식의 시작과 끝에 공백을 넣도록 (Note 1)
+  - explicit_init # 명시적인 init 호출을 하지 않도록 (Note 1)
+  - first_where # `.filter { … }.first` 보다 `.first(where: { … })`를 사용하도록 (Note 1, 5)
 
 excluded:
   - Pods


### PR DESCRIPTION
Swift3 대응 및 Swiftlint 버전업으로 인해 수정된 lint에 대해 PR 요청합니다.
수정된 내역은 아래와 같습니다.

- conditional_binding_cascade 룰 제거 : 룰이 없어졌습니다.
- for_where 룰 제거 : Swiftlint 0.18.0에서 가독성 향상을 위해 추가된 룰이지만 조건절이 복잡할 경우 오히려 가독성이 떨어져 제외하기로 했습니다.
- empty_count 룰 추가 : count에 접근하여 수를 확인하기 보다 isEmpty를 사용하는 것이 내부적으로 더 빠르고 Kotlin과 통일감을 주기 위함입니다.
- closure_end_indentation 룰 추가 : Xcode에서 제대로 잡아주지 않는 클로저의 들여쓰기를 잡기 위해 추가 했습니다.
- closure_spacing 룰 추가 : 싱글 라인 클로저의 가독성을 위해 추가 했습니다.
- explicit_init 룰 추가 : 명시적인 init의 호출이 무의미하기 때문에 제외하기로 했습니다.
- first_where 룰 추가 : 내부적으로 더 빠른 문법을 권장하기 위해 추가 했습니다.